### PR TITLE
Node local path fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+#* text=auto
 
 # Custom for Visual Studio
 *.cs     diff=csharp

--- a/KSPModAdmin.Core/Model/ModNode.cs
+++ b/KSPModAdmin.Core/Model/ModNode.cs
@@ -114,7 +114,7 @@ namespace KSPModAdmin.Core.Model
                     //DownloadDate = value.DownloadDate;
                     Downloads = value.Downloads;
                     //LocalPath = value.LocalPath;
-                    //Key = value.LocalPath;
+                    Key = value.LocalPath;
                     Name = value.Name;
                     ProductID = value.ProductID;
                     Rating = value.Rating;


### PR DESCRIPTION
I had some issues with an attempted github fix and reverted back to the current dev branch. However, that change also seems to have broken adding mods in any way, in that they never get a local path. I traced it to line 117 here and fixed it, but I don't know if it's supposed to be this way or not.

On a side note, the change to the .gitattributes file here fixes the persistent 'modified rus.lang' file issue I've been having.