### PR TITLE
GitHub prerelease fix

### DIFF
--- a/KSPModAdmin.Core/Utils/SiteHandler/GitHubHandler.cs
+++ b/KSPModAdmin.Core/Utils/SiteHandler/GitHubHandler.cs
@@ -123,6 +123,15 @@ namespace KSPModAdmin.Core.Utils.SiteHandler
             var downloadInfos = GetDownloadInfo(modInfo);
             DownloadInfo selected = null;
 
+			// If any of the nodes came back as a prerelease, notify the user that there are pre-release nodes
+	        foreach (var d in downloadInfos)
+	        {
+		        if (!d.Name.Contains("Pre-release")) continue;
+
+		        var dlg = MessageBox.Show("This download contains a pre-release version. This version might not be stable.", Messages.MSG_TITLE_ATTENTION, MessageBoxButtons.OK);
+		        break;
+	        }
+
             if (downloadInfos.Count > 1)
             {
                 // create new selection form if more than one download option found
@@ -268,26 +277,49 @@ namespace KSPModAdmin.Core.Utils.SiteHandler
 
             var releases = new List<DownloadInfo>();
 
-            var nodes = htmlDoc.DocumentNode.SelectNodes("//*[@class='release label-latest']/div[2]/ul/li/a");
+            var nodesrel = htmlDoc.DocumentNode.SelectNodes("//*[@class='release label-latest']/div[2]/ul/li/a");
 
-            if (nodes == null)
-                return releases;
+			var nodespre = htmlDoc.DocumentNode.SelectNodes("//*[@class='release label-prerelease'][1]/div[2]/ul/li/a");
 
-            foreach (var s in nodes)
-            {
-                var url = "https://github.com" + s.Attributes["href"].Value;
+	        if (nodesrel != null)
+			{
+				foreach (var s in nodesrel)
+				{
+					var url = "https://github.com" + s.Attributes["href"].Value;
 
-                if (!url.Contains("releases")) continue;
+					if (!url.Contains("releases")) continue;
 
-                var dInfo = new DownloadInfo
-                {
-                    DownloadURL = url,
-                    Filename = GetUrlParts(url).Last(),
-                    Name = Path.GetFileNameWithoutExtension(GetUrlParts(url).Last())
-                };
+					var dInfo = new DownloadInfo
+					{
+						DownloadURL = url,
+						Filename = GetUrlParts(url).Last(),
+						Name = Path.GetFileNameWithoutExtension(GetUrlParts(url).Last())
+					};
 
-                releases.Add(dInfo);
-            }
+					releases.Add(dInfo);
+				}
+	        }
+
+	        if (nodespre != null)
+			{
+				foreach (var s in nodespre)
+				{
+					var url = "https://github.com" + s.Attributes["href"].Value;
+
+					if (!url.Contains("releases")) continue;
+
+					var versionNode = htmlDoc.DocumentNode.SelectSingleNode("//*[@class='release label-prerelease']/div[1]/ul/li[1]/a/span[2]").InnerText;
+
+					var dInfo = new DownloadInfo
+					{
+						DownloadURL = url,
+						Filename = GetUrlParts(url).Last(),
+						Name = "Pre-release: " + versionNode + ": " + Path.GetFileNameWithoutExtension(GetUrlParts(url).Last())
+					};
+
+					releases.Add(dInfo);
+				}
+	        }
 
             return releases;
         }

--- a/KSPModAdmin.Core/Views/frmSelectDownload.cs
+++ b/KSPModAdmin.Core/Views/frmSelectDownload.cs
@@ -30,6 +30,7 @@ namespace KSPModAdmin.Core.Views
                     foreach (var e in value)
                         cbLinks.Items.Add(e);
                     cbLinks.SelectedItem = cbLinks.Items[0];
+	                cbLinks.DropDownWidth = DropDownWidth(cbLinks);
                 }
                 else
                     cbLinks.SelectedItem = null;
@@ -118,5 +119,20 @@ namespace KSPModAdmin.Core.Views
         {
             return new KSPDialogResult(DialogResult, SelectedLink);
         }
+
+
+		int DropDownWidth(ComboBox myCombo)
+		{
+			int maxWidth = 0, temp = 0;
+			foreach (var obj in myCombo.Items)
+			{
+				temp = TextRenderer.MeasureText(obj.ToString(), myCombo.Font).Width;
+				if (temp > maxWidth)
+				{
+					maxWidth = temp;
+				}
+			}
+			return maxWidth;
+		}
     }
 }


### PR DESCRIPTION
Fixed github links not working at all for pages with a Pre-release.
 - Added new functionality to github downloading. If a repo has a primary release and a pre-release, both will be checked for files, and a selection window will pop up asking the user to select the file they want. Pre-release files get labeled as such.

Changed the combobox on frmSelectDownload to be the width of the contents, so that the full link path is visible.