### PR TITLE
Project rearangements for monodevelop compatibility

### DIFF
--- a/KSPModAdmin.Core/Constants.cs
+++ b/KSPModAdmin.Core/Constants.cs
@@ -38,7 +38,7 @@ namespace KSPModAdmin.Core
 
         // KSP MA folders
         public const string PLUGIN_FOLDER = "Plugins";
-        public const string LANGUAGE_FOLDER = "lang"; // "Languages";
+        public const string LANGUAGE_FOLDER = "Languages";
 
         // KSP folders
         public const string KSP_ROOT = "KSP_Root";

--- a/KSPModAdmin.Core/Controller/MainController.cs
+++ b/KSPModAdmin.Core/Controller/MainController.cs
@@ -299,7 +299,11 @@ namespace KSPModAdmin.Core.Controller
             try
             {
                 Localizer.GlobalInstance.DefaultLanguage = "eng";
-                langLoadFailed = !Localizer.GlobalInstance.LoadLanguages(KSPPathHelper.GetPath(KSPPaths.LanguageFolder), true);
+                langLoadFailed = !Localizer.GlobalInstance.LoadLanguages(new [] 
+                    {
+                        KSPPathHelper.GetPath(KSPPaths.LanguageFolder), 
+                        Path.Combine(KSPPathHelper.GetPath(KSPPaths.KSPMA_Plugins), Constants.LANGUAGE_FOLDER) 
+                    }, true);
             }
             catch (Exception ex)
             {

--- a/KSPModAdmin.Core/KSPModAdmin.Core.csproj
+++ b/KSPModAdmin.Core/KSPModAdmin.Core.csproj
@@ -68,12 +68,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\sharpcompress.0.10.3\lib\net40\SharpCompress.dll</HintPath>
     </Reference>
-    <Reference Include="StyleCop">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.dll</HintPath>
-    </Reference>
-    <Reference Include="StyleCop.CSharp">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />

--- a/KSPModAdmin.Core/Utils/Localization/Localizer.cs
+++ b/KSPModAdmin.Core/Utils/Localization/Localizer.cs
@@ -189,15 +189,38 @@ namespace KSPModAdmin.Core.Utils.Localization
         /// <summary>
         /// Loads all available languages from the passed directory.
         /// </summary>
+        /// <param name="languageFolderPaths">Paths to the language files.</param>
+        /// <returns>True, if load was without any errors.</returns>
+        public bool LoadLanguages(string[] languageFolderPaths, bool defaultLanguageRequired = false, bool xml = true)
+        {
+            List<string> allLangFiles = new List<string>();
+            foreach (var path in languageFolderPaths)
+            {
+                if (!Directory.Exists(path))
+                    continue;
+
+                string[] langFiles = Directory.GetFiles(path, LANG_FILE_EXTENSION);
+                allLangFiles.AddRange(langFiles);
+            }
+
+            if (allLangFiles.Count == 0)
+                return false;
+
+            return LoadLanguageFiles(allLangFiles.ToArray(), defaultLanguageRequired, xml);
+        }
+
+        /// <summary>
+        /// Loads all available languages from the passed directory.
+        /// </summary>
         /// <param name="languageFolderPath">Path to the language files.</param>
         /// <returns>True, if load was without any errors.</returns>
         public bool LoadLanguages(string languageFolderPath, bool defaultLanguageRequired = false, bool xml = true)
         {
             if (!Directory.Exists(languageFolderPath))
                 return false;
-            
+
             string[] langFiles = Directory.GetFiles(languageFolderPath, LANG_FILE_EXTENSION);
-            return LoadLanguages(langFiles, defaultLanguageRequired, xml);
+            return LoadLanguageFiles(langFiles, defaultLanguageRequired, xml);
         }
 
         /// <summary>
@@ -205,7 +228,7 @@ namespace KSPModAdmin.Core.Utils.Localization
         /// </summary>
         /// <param name="langFiles">Array of paths to the language files.</param>
         /// <returns>True, if load was without any errors.</returns>
-        public bool LoadLanguages(string[] langFiles, bool defaultLanguageRequired = false, bool xml = true)
+        public bool LoadLanguageFiles(string[] langFiles, bool defaultLanguageRequired = false, bool xml = true)
         {
             bool result = false;
             if (langFiles.Length <= 0)

--- a/KSPModAdmin.Core/packages.config
+++ b/KSPModAdmin.Core/packages.config
@@ -3,6 +3,5 @@
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net40" />
   <package id="sharpcompress" version="0.10.3" targetFramework="net40" />
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net40" />
 </packages>

--- a/KSPModAdmin.Plugin.BackupTab/KSPModAdmin.Plugin.BackupTab.csproj
+++ b/KSPModAdmin.Plugin.BackupTab/KSPModAdmin.Plugin.BackupTab.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Debug\Plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,14 +25,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Release\Plugins\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug MONO|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug MONO\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Debug MONO\Plugins\</OutputPath>
     <DefineConstants>TRACE;DEBUG;__MonoCS__</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -40,7 +40,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release MONO|AnyCPU'">
-    <OutputPath>bin\Release MONO\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Release MONO\Plugins\</OutputPath>
     <DefineConstants>TRACE;__MonoCS__</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -52,12 +52,6 @@
     <Reference Include="SharpCompress, Version=0.10.3.0, Culture=neutral, PublicKeyToken=beaf6f427e128133, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\sharpcompress.0.10.3\lib\net40\SharpCompress.dll</HintPath>
-    </Reference>
-    <Reference Include="StyleCop">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.dll</HintPath>
-    </Reference>
-    <Reference Include="StyleCop.CSharp">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -107,9 +101,15 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Languages\KSPMA.BackupTabPlugin.ger.lang" />
-    <None Include="Languages\KSPMA.BackupTabPlugin.eng.lang" />
-    <None Include="Languages\KSPMA.BackupTabPlugin.fake.lang" />
+    <Content Include="Languages\KSPMA.BackupTabPlugin.ger.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.BackupTabPlugin.eng.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.BackupTabPlugin.fake.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
     <None Include="Properties\DataSources\LanguageEntry.datasource" />
     <None Include="Settings.StyleCop" />
@@ -210,7 +210,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /E /Y /R /I "$(ProjectDir)Languages" "$(SolutionDir)KSPModAdmin\$(OutDir)lang"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/KSPModAdmin.Plugin.BackupTab/packages.config
+++ b/KSPModAdmin.Plugin.BackupTab/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="sharpcompress" version="0.10.3" targetFramework="net40" />
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net40" />
 </packages>

--- a/KSPModAdmin.Plugin.FlagsTab/KSPModAdmin.Plugin.FlagsTab.csproj
+++ b/KSPModAdmin.Plugin.FlagsTab/KSPModAdmin.Plugin.FlagsTab.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Debug\Plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,14 +25,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Release\Plugins\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug MONO|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug MONO\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Debug MONO\Plugins\</OutputPath>
     <DefineConstants>TRACE;DEBUG;__MonoCS__</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -40,7 +40,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release MONO|AnyCPU'">
-    <OutputPath>bin\Release MONO\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Release MONO\Plugins\</OutputPath>
     <DefineConstants>TRACE;__MonoCS__</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -49,12 +49,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StyleCop">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.dll</HintPath>
-    </Reference>
-    <Reference Include="StyleCop.CSharp">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -93,9 +87,15 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Languages\KSPMA.FlagsTabPlugin.eng.lang" />
-    <None Include="Languages\KSPMA.FlagsTabPlugin.ger.lang" />
-    <None Include="Languages\KSPMA.FlagsTabPlugin.fake.lang" />
+    <Content Include="Languages\KSPMA.FlagsTabPlugin.eng.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.FlagsTabPlugin.ger.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.FlagsTabPlugin.fake.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
     <None Include="Settings.StyleCop" />
   </ItemGroup>
@@ -129,7 +129,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /E /Y /R /I "$(ProjectDir)Languages" "$(SolutionDir)KSPModAdmin\$(OutDir)lang"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/KSPModAdmin.Plugin.FlagsTab/packages.config
+++ b/KSPModAdmin.Plugin.FlagsTab/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net40" />
 </packages>

--- a/KSPModAdmin.Plugin.PartsAndCraftsTab/KSPModAdmin.Plugin.PartsAndCraftsTab.csproj
+++ b/KSPModAdmin.Plugin.PartsAndCraftsTab/KSPModAdmin.Plugin.PartsAndCraftsTab.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Debug\Plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,14 +25,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Release\Plugins\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug MONO|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug MONO\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Debug MONO\Plugins\</OutputPath>
     <DefineConstants>TRACE;DEBUG;__MonoCS__</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -40,7 +40,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release MONO|AnyCPU'">
-    <OutputPath>bin\Release MONO\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Release MONO\Plugins\</OutputPath>
     <DefineConstants>TRACE;__MonoCS__</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -49,12 +49,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StyleCop">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.dll</HintPath>
-    </Reference>
-    <Reference Include="StyleCop.CSharp">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -116,9 +110,15 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Languages\KSPMA.PartsAndCraftsTabPlugin.ger.lang" />
-    <None Include="Languages\KSPMA.PartsAndCraftsTabPlugin.eng.lang" />
-    <None Include="Languages\KSPMA.PartsAndCraftsTabPlugin.fake.lang" />
+    <Content Include="Languages\KSPMA.PartsAndCraftsTabPlugin.ger.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.PartsAndCraftsTabPlugin.eng.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.PartsAndCraftsTabPlugin.fake.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
     <None Include="Properties\DataSources\LanguageEntry.datasource" />
     <None Include="Settings.StyleCop" />
@@ -213,7 +213,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /E /Y /R /I "$(ProjectDir)Languages" "$(SolutionDir)KSPModAdmin\$(OutDir)lang"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/KSPModAdmin.Plugin.PartsAndCraftsTab/packages.config
+++ b/KSPModAdmin.Plugin.PartsAndCraftsTab/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net40" />
 </packages>

--- a/KSPModAdmin.Plugin.Template/KSPModAdmin.Plugin.Template.csproj
+++ b/KSPModAdmin.Plugin.Template/KSPModAdmin.Plugin.Template.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Debug\Plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,14 +25,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Release\Plugins\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug MONO|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug MONO\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Debug MONO\Plugins\</OutputPath>
     <DefineConstants>TRACE;DEBUG;__MonoCS__</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -40,7 +40,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release MONO|AnyCPU'">
-    <OutputPath>bin\Release MONO\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Release MONO\Plugins\</OutputPath>
     <DefineConstants>TRACE;__MonoCS__</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -49,12 +49,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StyleCop">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.dll</HintPath>
-    </Reference>
-    <Reference Include="StyleCop.CSharp">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -92,8 +86,12 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Languages\KSPMA.TemplatePlugin.eng.lang" />
-    <None Include="Languages\KSPMA.TemplatePlugin.fake.lang" />
+    <Content Include="Languages\KSPMA.TemplatePlugin.eng.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.TemplatePlugin.fake.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
     <None Include="Properties\DataSources\LanguageEntry.datasource" />
     <None Include="Settings.StyleCop" />
@@ -110,7 +108,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /E /Y /R /I "$(ProjectDir)Languages" "$(SolutionDir)KSPModAdmin\$(OutDir)lang"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/KSPModAdmin.Plugin.Template/packages.config
+++ b/KSPModAdmin.Plugin.Template/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net40" />
 </packages>

--- a/KSPModAdmin.Plugin.Translation.Executable/KSPModAdmin.Plugin.Translation.Executable.csproj
+++ b/KSPModAdmin.Plugin.Translation.Executable/KSPModAdmin.Plugin.Translation.Executable.csproj
@@ -51,12 +51,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StyleCop">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.dll</HintPath>
-    </Reference>
-    <Reference Include="StyleCop.CSharp">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/KSPModAdmin.Plugin.Translation.Executable/packages.config
+++ b/KSPModAdmin.Plugin.Translation.Executable/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net40" />
 </packages>

--- a/KSPModAdmin.Plugin.Translation/KSPModAdmin.Plugin.Translation.csproj
+++ b/KSPModAdmin.Plugin.Translation/KSPModAdmin.Plugin.Translation.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Debug\Plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,14 +25,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Release\Plugins\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug MONO|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug MONO\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Debug MONO\Plugins\</OutputPath>
     <DefineConstants>TRACE;DEBUG;__MonoCS__</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -40,7 +40,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release MONO|AnyCPU'">
-    <OutputPath>bin\Release MONO\</OutputPath>
+    <OutputPath>..\KSPModAdmin\bin\Release MONO\Plugins\</OutputPath>
     <DefineConstants>TRACE;__MonoCS__</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -49,12 +49,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StyleCop">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.dll</HintPath>
-    </Reference>
-    <Reference Include="StyleCop.CSharp">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -95,9 +89,15 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Languages\KSPMA.TranslationPlugin.eng.lang" />
-    <None Include="Languages\KSPMA.TranslationPlugin.fake.lang" />
-    <None Include="Languages\KSPMA.TranslationPlugin.ger.lang" />
+    <Content Include="Languages\KSPMA.TranslationPlugin.eng.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.TranslationPlugin.fake.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.TranslationPlugin.ger.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
     <None Include="Properties\DataSources\LanguageEntry.datasource" />
     <None Include="Settings.StyleCop" />
@@ -123,7 +123,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /E /Y /R /I "$(ProjectDir)Languages" "$(SolutionDir)KSPModAdmin\$(OutDir)lang"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/KSPModAdmin.Plugin.Translation/packages.config
+++ b/KSPModAdmin.Plugin.Translation/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net40" />
 </packages>

--- a/KSPModAdmin.Updater/KSPModAdmin.Updater.csproj
+++ b/KSPModAdmin.Updater/KSPModAdmin.Updater.csproj
@@ -93,12 +93,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\sharpcompress.0.10.3\lib\net40\SharpCompress.dll</HintPath>
     </Reference>
-    <Reference Include="StyleCop">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.dll</HintPath>
-    </Reference>
-    <Reference Include="StyleCop.CSharp">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
@@ -119,7 +113,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "$(SolutionDir)KSPModAdmin\$(OutDir)$(TargetFileName)"
+    <PostBuildEvent>
 </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />

--- a/KSPModAdmin.Updater/packages.config
+++ b/KSPModAdmin.Updater/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="sharpcompress" version="0.10.3" targetFramework="net40" />
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net40" />
 </packages>

--- a/KSPModAdmin/KSPModAdmin.csproj
+++ b/KSPModAdmin/KSPModAdmin.csproj
@@ -58,12 +58,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StyleCop">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.dll</HintPath>
-    </Reference>
-    <Reference Include="StyleCop.CSharp">
-      <HintPath>..\packages\StyleCop.4.7.49.0\lib\net35\StyleCop.CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http">
@@ -84,15 +78,23 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
-    <None Include="Languages\KSPMA.eng.lang">
+    <Content Include="Languages\KSPMA.eng.lang">
       <SubType>Designer</SubType>
-    </None>
-    <None Include="Languages\KSPMA.fake.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.fake.lang">
       <SubType>Designer</SubType>
-    </None>
-    <None Include="Languages\KSPMA.ger.lang" />
-    <None Include="Languages\KSPMA.ital.lang" />
-    <None Include="Languages\KSPMA.rus.lang" />
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.ger.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.ital.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\KSPMA.rus.lang">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
     <None Include="Pics\KSPMA Icon\KMA_and_KMA2_icon.psd" />
     <None Include="Pics\KSPMA Icon\KMA_Vectors.ai" />
@@ -155,12 +157,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /E /Y /R /I "$(ProjectDir)Languages" "$(ProjectDir)$(OutDir)lang"
-md "$(ProjectDir)$(OutDir)Plugins"
-xcopy /E /Y /R /I "$(SolutionDir)KSPModAdmin.Plugin.Translation\$(OutDir)KSPModAdmin.Plugin.Translation.dll" "$(ProjectDir)$(OutDir)Plugins"
-xcopy /E /Y /R /I "$(SolutionDir)KSPModAdmin.Plugin.BackupTab\$(OutDir)KSPModAdmin.Plugin.BackupTab.dll" "$(ProjectDir)$(OutDir)Plugins"
-xcopy /E /Y /R /I "$(SolutionDir)KSPModAdmin.Plugin.FlagsTab\$(OutDir)KSPModAdmin.Plugin.FlagsTab.dll" "$(ProjectDir)$(OutDir)Plugins"
-xcopy /E /Y /R /I "$(SolutionDir)KSPModAdmin.Plugin.PartsAndCraftsTab\$(OutDir)KSPModAdmin.Plugin.PartsAndCraftsTab.dll" "$(ProjectDir)$(OutDir)Plugins"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/KSPModAdmin/packages.config
+++ b/KSPModAdmin/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net40" />
 </packages>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -3,6 +3,7 @@
   <repository path="..\KSPModAdmin.Core\packages.config" />
   <repository path="..\KSPModAdmin.Plugin.BackupTab\packages.config" />
   <repository path="..\KSPModAdmin.Plugin.FlagsTab\packages.config" />
+  <repository path="..\KSPModAdmin.Plugin.PartsAndCraftsTab\packages.config" />
   <repository path="..\KSPModAdmin.Plugin.Template\packages.config" />
   <repository path="..\KSPModAdmin.Plugin.Translation.Executable\packages.config" />
   <repository path="..\KSPModAdmin.Plugin.Translation\packages.config" />


### PR DESCRIPTION
- All post build event actions removed.
- Output directory of plugin projects changed to "..\KSPModAdmin\bin\<BuildConfiguration>\Plugins\"
- StyleCop DLLs removed (not needed).
- Language files will now be auto copy to output dir.
- Language loading changed, to be able to load from more then one language dir.